### PR TITLE
Add RDlto to test R with --enable-lto

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository contains a Dockerfile for creating an Docker image, `wch1/r-debu
 * `RDcsan`: R-devel compiled with clang, Address Sanitizer and Undefined Behavior Sanitizer.
 * `RDstrictbarrier`: R-devel compiled with `--enable-strict-barrier`. This can be used with `gctorture(TRUE)`, or `gctorture2(1, inhibit_release=TRUE)`.
 * `RDthreadcheck`: R-devel compiled with `-DTHREADCHECK`, which causes it to detect if memory management functions are called from the wrong thread.
+* `RDlto`: R-devel compiled with `--enable-lto`
 
 
 See [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Checking-memory-access) for more information about these builds (except for the threadcheck build, which is not documented there.)

--- a/buildall.sh
+++ b/buildall.sh
@@ -17,4 +17,5 @@ docker build -t wch1/r-debug-1 r-debug-1
 docker build -t wch1/r-debug-2 r-debug-2
 docker build -t wch1/r-debug-3 r-debug-3
 docker build -t wch1/r-debug-4 r-debug-4
+docker build -t wch1/r-debug-5 r-debug-5
 docker build -t wch1/r-debug   r-debug

--- a/debugging-r.md
+++ b/debugging-r.md
@@ -73,6 +73,7 @@ The r-debug docker image contains the following:
 * `RDcsan`: R-devel compiled with clang, Address Sanitizer and Undefined Behavior Sanitizer.
 * `RDstrictbarrier`: R-devel compiled with `--enable-strict-barrier`. This can be used with `gctorture(TRUE)`, or `gctorture2(1, inhibit_release=TRUE)`.
 * `RDthreadcheck`: R-devel compiled with `-DTHREADCHECK`, which causes it to detect if memory management functions are called from the wrong thread.
+* `RDlto`: R-devel compiled with `--enable-lto`
 
 Each of the builds of R has its own libpath, so that a package installed with one build will not be accidentally used by another. Each one comes with devtools and Rcpp installed.
 

--- a/r-debug-5/Dockerfile
+++ b/r-debug-5/Dockerfile
@@ -1,0 +1,9 @@
+# To build from the parent directory:
+#   docker build -t wch1/r-debug-5 r-debug-5
+
+FROM wch1/r-debug-4
+
+# RDlto: R built with --enable-lto
+RUN /tmp/buildR.sh lto
+RUN RDlto -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
+RUN RDlto -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug/Dockerfile
+++ b/r-debug/Dockerfile
@@ -1,7 +1,7 @@
 # To build from the parent directory:
 #   docker build -t wch1/r-debug r-debug
 
-FROM wch1/r-debug-4
+FROM wch1/r-debug-5
 
 # RDthreadcheck: Make sure that R's memory management functions are called
 # only from the main R thread.

--- a/r-devel/buildR.sh
+++ b/r-devel/buildR.sh
@@ -65,6 +65,10 @@ elif [[ "$1" = "threadcheck" ]]; then
     export CFLAGS="${CFLAGS} -DTHREADCHECK"
     export CXXFLAGS="${CXXFLAGS} -DTHREADCHECK"
     configure_flags="--without-recommended-packages"
+
+elif [[ "$1" = "lto" ]]; then
+    suffix="lto"
+    configure_flags="--enable-lto"
 fi
 
 dirname="RD${suffix}"


### PR DESCRIPTION
I've got an LTO failure on CRAN, and I'm not aware of any other docker image or CI service that has an R build with `--enable-lto` like https://www.stats.ox.ac.uk/pub/bdr/LTO/README.txt. Since r-debug ships lots of other variations of R built with different configure flags, I thought it might make sense to add it here. Let me know what you think.