### PR TITLE
Install cpp11 and decor

### DIFF
--- a/r-debug-1/Dockerfile
+++ b/r-debug-1/Dockerfile
@@ -6,4 +6,4 @@ FROM wch1/r-devel
 # RDvalgrind: Install R-devel with valgrind level 2 instrumentation
 RUN /tmp/buildR.sh valgrind
 RUN RDvalgrind -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
-RUN RDvalgrind -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'
+RUN RDvalgrind -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug-2/Dockerfile
+++ b/r-debug-2/Dockerfile
@@ -5,4 +5,4 @@ FROM wch1/r-debug-1
 
 RUN /tmp/buildR.sh san
 RUN RDsan -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
-RUN RDsan -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'
+RUN RDsan -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug-3/Dockerfile
+++ b/r-debug-3/Dockerfile
@@ -13,4 +13,4 @@ RUN sed -i 's/^#!\/bin\/bash/#!\/bin\/bash\nulimit -Ss 131072/' /usr/local/bin/R
 RUN echo "\nulimit -Ss 131072" >> $HOME/.bashrc
 
 RUN RDcsan -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
-RUN RDcsan -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'
+RUN RDcsan -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug-4/Dockerfile
+++ b/r-debug-4/Dockerfile
@@ -6,4 +6,4 @@ FROM wch1/r-debug-3
 # RDstrictbarrier: Make sure that R objects are protected properly.
 RUN /tmp/buildR.sh strictbarrier
 RUN RDstrictbarrier -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
-RUN RDstrictbarrier -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'
+RUN RDstrictbarrier -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug/Dockerfile
+++ b/r-debug/Dockerfile
@@ -7,4 +7,4 @@ FROM wch1/r-debug-4
 # only from the main R thread.
 RUN /tmp/buildR.sh threadcheck
 RUN RDthreadcheck -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
-RUN RDthreadcheck -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'
+RUN RDthreadcheck -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-devel/Dockerfile
+++ b/r-devel/Dockerfile
@@ -147,4 +147,4 @@ RUN RD -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev
 RUN RD -q -e 'pak::pkg_install(c("BH", "R6", "magrittr"), "/usr/local/RD/lib/R/library")'
 
 # Finally, install some common packages specific to this build of R.
-RUN RD -q -e 'pak::pkg_install(c("devtools", "Rcpp", "roxygen2", "testthat", "memoise", "rmarkdown"))'
+RUN RD -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'


### PR DESCRIPTION
in all versions.

I wonder if the installation of packages should be part of the `buildR.sh` script.