### PR TITLE
Prepare images for arm64 compatibility

### DIFF
--- a/r-debug-1/Dockerfile
+++ b/r-debug-1/Dockerfile
@@ -5,5 +5,5 @@ FROM wch1/r-devel
 
 # RDvalgrind: Install R-devel with valgrind level 2 instrumentation
 RUN /tmp/buildR.sh valgrind
-RUN RDvalgrind -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
+RUN RDvalgrind -q -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
 RUN RDvalgrind -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug-2/Dockerfile
+++ b/r-debug-2/Dockerfile
@@ -4,5 +4,5 @@
 FROM wch1/r-debug-1
 
 RUN /tmp/buildR.sh san
-RUN RDsan -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
+RUN RDsan -q -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
 RUN RDsan -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug-3/Dockerfile
+++ b/r-debug-3/Dockerfile
@@ -12,5 +12,5 @@ RUN sed -i 's/^#!\/bin\/bash/#!\/bin\/bash\nulimit -Ss 131072/' /usr/local/bin/R
 # Increase stack size in .bashrc, so that it is picked up by RDscriptcsan.
 RUN echo "\nulimit -Ss 131072" >> $HOME/.bashrc
 
-RUN RDcsan -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
+RUN RDcsan -q -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
 RUN RDcsan -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug-4/Dockerfile
+++ b/r-debug-4/Dockerfile
@@ -5,5 +5,5 @@ FROM wch1/r-debug-3
 
 # RDstrictbarrier: Make sure that R objects are protected properly.
 RUN /tmp/buildR.sh strictbarrier
-RUN RDstrictbarrier -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
+RUN RDstrictbarrier -q -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
 RUN RDstrictbarrier -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-debug/Dockerfile
+++ b/r-debug/Dockerfile
@@ -6,5 +6,5 @@ FROM wch1/r-debug-4
 # RDthreadcheck: Make sure that R's memory management functions are called
 # only from the main R thread.
 RUN /tmp/buildR.sh threadcheck
-RUN RDthreadcheck -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev")'
+RUN RDthreadcheck -q -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
 RUN RDthreadcheck -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown"))'

--- a/r-devel/Dockerfile
+++ b/r-devel/Dockerfile
@@ -17,16 +17,15 @@ MAINTAINER Winston Chang "winston@rstudio.com"
 # Don't print "debconf: unable to initialize frontend: Dialog" messages
 ARG DEBIAN_FRONTEND=noninteractive
 
+# https://blog.thesparktree.com/docker-multi-arch-github-actions
+ARG TARGETARCH
+
 # Need this to add R repo
 RUN apt-get update && apt-get install -y software-properties-common wget dirmngr
 
 # LLVM-15
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
-
-# Add R apt repository
-RUN wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
-RUN add-apt-repository "deb http://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
 
 # Install basic stuff, R, and other packages that are useful for compiling R
 # and R packages.
@@ -37,9 +36,7 @@ RUN apt-get update && apt-get install -y \
     vim \
     less \
     wget \
-    r-base \
-    r-base-dev \
-    r-recommended \
+    curl \
     automake \
     libtool \
     fonts-texgyre \
@@ -82,26 +79,28 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 800 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 \
     --slave /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-15
 
+# https://blog.thesparktree.com/docker-multi-arch-github-actions
+RUN case ${TARGETARCH} in \
+            "amd64")  RIG_ARCH=  ;; \
+            "arm64")  RIG_ARCH=-arm64  ;; \
+            *) false ;; \
+        esac \
+    && curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux${RIG_ARCH}-latest.tar.gz | tar xz -C /usr/local \
+    && rig add
 
-RUN echo 'options(\n\
-  repos = c(CRAN = "https://cloud.r-project.org/"),\n\
-  download.file.method = "libcurl",\n\
-  # Detect number of physical cores\n\
-  Ncpus = parallel::detectCores(logical=FALSE)\n\
-)' >> /etc/R/Rprofile.site
-
+# Install some common packages specific to R-release
+RUN R -q -e 'pak::pkg_install(c("devtools", "Rcpp", "cpp11", "decor", "roxygen2", "testthat", "memoise", "rmarkdown", "tinytex"))'
 
 # Install TinyTeX (subset of TeXLive)
 # From FAQ 5 and 6 here: https://yihui.name/tinytex/faq/
 # Also install ae, parskip, and listings packages to build R vignettes
 RUN wget -qO- \
-    "https://yihui.org/gh/tinytex/tools/install-unx.sh" | \
-    sh -s - --admin --no-path \
+    "https://yihui.org/gh/tinytex/tools/install-unx.sh" | sh -s - --admin --no-path \
     && ~/.TinyTeX/bin/*/tlmgr path add \
     && tlmgr install metafont mfware inconsolata tex ae parskip listings xcolor \
              epstopdf-pkg pdftexcmds kvoptions texlive-scripts grfext \
     && tlmgr path add \
-    && Rscript -e "install.packages('tinytex'); tinytex::r_texmf()"
+    && Rscript -e "tinytex::r_texmf()"
 
 
 # =====================================================================

--- a/r-devel/Dockerfile
+++ b/r-devel/Dockerfile
@@ -143,7 +143,7 @@ RUN /tmp/buildR.sh
 # Install some commonly-used packages to a location used by all the RD*
 # installations. These packages do not have compiled code and do not depend on
 # packages that have compiled code.
-RUN RD -q -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/", "/usr/local/RD/lib/R/library")'
+RUN RD -q -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch), "/usr/local/RD/lib/R/library")'
 RUN RD -q -e 'pak::pkg_install(c("BH", "R6", "magrittr"), "/usr/local/RD/lib/R/library")'
 
 # Finally, install some common packages specific to this build of R.

--- a/r-devel/Dockerfile
+++ b/r-devel/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libgit2-dev \
     libxml2-dev \
+    libreadline-dev \
     texinfo \
     rsync \
     default-jdk \


### PR DESCRIPTION
I'm struggling to run the images (or R, for that matter) on my M2 in a virtual machine using Rosetta. I'm experimenting with arm64 images in https://github.com/cynkra/r-debug. These Dockerfiles have worked for me on arm64, chances are that they will continue to work on amd64.

Are you open to building multi-arch images in this repo, and perhaps to hosting them (also) on the GitHub container registry? What does CI/CD for these images currently look like?